### PR TITLE
fix: allow node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tsconfig.json"
   ],
   "engines": {
-    "node": "14 || 16"
+    "node": "14 || 16 || 18"
   },
   "keywords": [
     "typescript",


### PR DESCRIPTION
Evolve needs it to solve CI problems related to commit-lint.
