### PR TITLE
TSconfig version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "semantic-release": "21.0.1"
   },
   "peerDependencies": {
-    "typescript": ">=4"
+    "typescript": ">=5"
   },
   "files": [
     "tsconfig.json"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     // type checking
     "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
     "strict": true,
 
     // modules

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
 
     // modules
     "module": "es2020",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
 
     // emit


### PR DESCRIPTION
- feat!: enable `noUncheckedIndexedAccess` rule

```ts
interface Environment {
  name: string
  os: string
  [key: string]: string
}

const env: Environment = {
  name: "name",
  os: "os",
}

const { name, os, blabla } = env

// with `"noUncheckedIndexedAccess": false`, type of `blabla` is `string`, which makes this all good from a TypeScript perspective, but leads to runtime error:
console.log(name, os, blabla.toString())

// with `"noUncheckedIndexedAccess": true`, type of `blabla` is `string | undefined` which catches the potential runtime error in the type level:
console.log(name, os, blabla.toString()) // 'blabla' is possibly 'undefined'.ts(18048)
console.log(name, os, blabla?.toString()) // all good!
```

- feat!: change `moduleResolution` to `bundler`

Makes TypeScript resolve files in a way similar to how Vite and other bundlers resolve files. Documentation: https://github.com/microsoft/TypeScript/pull/51669 Evan You (creator of Vite) explicitly recommends using this for Vite apps: https://twitter.com/youyuxi/status/1636551895002255362

`"moduleResolution": "bundler"` makes module resolution respect package.json `exports` field. One implication of this is that you can't import from internal file structure unless it's allowed in the package's `exports` conditions.

```ts
// allowed in v1 with "moduleResolution": "node", but disallowed in v2
import { TextProps } from "@einride/ui/dist/components/typography/Text/Text
```

Disallowing this is a feature, since the internal file structure can change any time, and it's not been specified as allowed import path in package.json `exports`. There are often ways of solving it in other ways, as inferring types instead of importing:

```ts
// ok in v2
type TextProps = ComponentProps<typeof Text>
```

If something needs to be imported and can't be inferred or solve in another way, it should be officially exported instead.

Another problem is that `cypress.config.ts` is not being resolved correctly when switching `moduleResolution` to `bundler`. This is a known problem that Cypress is working on: https://github.com/cypress-io/cypress/issues/26308 Until it's solved upstream, a possible workaround it to rename the file to `cypress.config.mjs`, which removes the need for Cypress to transpile the config file to JavaScript. Another workaround is to explicitly set that `ts-node` should be using `"moduleResolution": "node"`: https://github.com/cypress-io/cypress/issues/26308#issuecomment-1499724602

- feat!: require typescript v5

Required for `"moduleResolution": "bundler"`.
