### PR TITLE
feat: set module detection to force

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     // landguage and environment
     "jsx": "react-jsx",
     "lib": ["es2021", "dom", "dom.iterable"],
+    "moduleDetection": "force",
     "target": "es2021",
 
     // completeness


### PR DESCRIPTION
We all have probably seen this error:

> Cannot redeclare block-scoped variable 'shipment'.

In many cases it makes sense. You can't redeclare a variable with the same name in the same scope. But this error also occurs in another situation, where it makes less sense.

Try creating a TypeScript file. Then write:

```ts
const name = "Filip" // ⛔️ Cannot redeclare block-scoped variable 'name'.
```

What? I didn't redeclare it – it's literally the only declaration in the scope and in the file.

However, the error goes away when I change the variable name:

```ts
const firstName = "Filip" // 👍
```

The error occurs for legacy reasons related to [scripts and modules in JavaScript](https://www.typescriptlang.org/docs/handbook/modules/theory.html#scripts-and-modules-in-javascript). By default, when there are no imports/exports, a TypeScript file will be treated as a script instead of a module. Scripts are loded via the`<script>` tag into the global scope. That means sharing scope with browser globals such as `name`.

The same thing happens in many situations:

```ts
const name = "" // ⛔️ Cannot redeclare block-scoped variable 'name'.
const event = "" // ⛔️ Cannot redeclare block-scoped variable 'event'.
const origin = "" // ⛔️ Cannot redeclare block-scoped variable 'origin'.
const history = "" // ⛔️ Cannot redeclare block-scoped variable 'history'.
const length = "" // ⛔️ Cannot redeclare block-scoped variable 'length'.
const location = "" // ⛔️ Cannot redeclare block-scoped variable 'location'.
const crypto = "" // ⛔️ Cannot redeclare block-scoped variable 'crypto'.
const parent = "" // ⛔️ Cannot redeclare block-scoped variable 'parent'.
const screen = "" // ⛔️ Cannot redeclare block-scoped variable 'screen'.
const top = "" // ⛔️ Cannot redeclare block-scoped variable 'top'.
const status = "" // ⛔️ Cannot redeclare block-scoped variable 'status'.
const close = "" // ⛔️ Cannot redeclare block-scoped variable 'close'.
const focus = "" // ⛔️ Cannot redeclare block-scoped variable 'focus'.
const document = "" // ⛔️ Cannot redeclare block-scoped variable 'document'.
```

The error goes away if you add an empty `export {}`:

```ts
const name = "Filip" // 👍

export {}
```

Adding `export {}` seems to be the most commonly recommended solution to the problem. In most cases, you'll export something from each TypeScript file, which means it's most likely not a problem in the end. But it's still confusing to see this error before you've added an export.

Since TypeScript v4.7, there is a better solution with the new compiler option `moduleDetection`: https://www.typescriptlang.org/tsconfig#moduleDetection

Setting it to `force` ensures that every non-declaration TypeScript file is treated as a module rather than a script – which is always what we want.

```ts
// with "moduleDetection": "force" in tsconfig.json compiler options
const name = "Filip" // 👍
```

I'd suggest we start using this option to avoid the redeclaration error where it doesn't make sense going forward!